### PR TITLE
Update lrucache.hpp

### DIFF
--- a/include/lrucache.hpp
+++ b/include/lrucache.hpp
@@ -49,6 +49,8 @@ public:
 			throw std::range_error("There is no such key in cache");
 		} else {
 			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+			// Should not the iterator in the map be updated as well?
+			// _cache_items_map.find[key] = _cache_items_list.begin();
 			return it->second->second;
 		}
 	}


### PR DESCRIPTION
> > _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
> > Should not we also update the iterator in the map for the key?
