### PR TITLE
Add manual eviction and move semantics

### DIFF
--- a/include/lrucache.hpp
+++ b/include/lrucache.hpp
@@ -25,14 +25,14 @@ public:
 		_max_size(max_size) {
 	}
 	
-	void put(const key_t& key, const value_t& value) {
+	void put(const key_t& key, value_t&& value) {
 		auto it = _cache_items_map.find(key);
 		if (it != _cache_items_map.end()) {
 			_cache_items_list.erase(it->second);
 			_cache_items_map.erase(it);
 		}
 			
-		_cache_items_list.push_front(key_value_pair_t(key, value));
+		_cache_items_list.push_front(key_value_pair_t(key, std::move(value)));
 		_cache_items_map[key] = _cache_items_list.begin();
 		
 		if (_cache_items_map.size() > _max_size) {
@@ -50,6 +50,18 @@ public:
 		} else {
 			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
 			return it->second->second;
+		}
+	}
+	
+	value_t evict(const key_t& key) {
+		auto it = _cache_items_map.find(key);
+		if (it == _cache_items_map.end()) {
+			throw std::range_error("There is no such key in cache");
+		} else {
+			value_t result = std::move(it->second->second);
+			_cache_items_list.erase(it->second);
+			_cache_items_map.erase(it);
+			return std::move(result);
 		}
 	}
 	


### PR DESCRIPTION
- Sometimes you need to evict an item from
  the cache (i.e. if you know the underlying
  object is no longer valid).
- Move semantics allow us to place objects in
  and evict objects from the cache without
  copying them.
- Bonus: It's now possible to pass non-copyable
  objects like unique_ptr through the cache,
  although you won't be able to retrieve them
  without eviction.
