### PR TITLE
Fix use after free

### DIFF
--- a/include/lrucache.hpp
+++ b/include/lrucache.hpp
@@ -27,12 +27,11 @@ public:
 	
 	void put(const key_t& key, const value_t& value) {
 		auto it = _cache_items_map.find(key);
+		_cache_items_list.push_front(key_value_pair_t(key, value));
 		if (it != _cache_items_map.end()) {
 			_cache_items_list.erase(it->second);
 			_cache_items_map.erase(it);
 		}
-			
-		_cache_items_list.push_front(key_value_pair_t(key, value));
 		_cache_items_map[key] = _cache_items_list.begin();
 		
 		if (_cache_items_map.size() > _max_size) {


### PR DESCRIPTION
Simple reproduction of the bug:
    LRUCache<string, string> lruCache(3);
    lruCache.put("key1", "val1");
    lruCache.put("key2", "val2");
    lruCache.put("key3", "val3");
    lruCache.put("key1", lruCache.get("key1"));
The get returns a ref to the value of "key1", the put gets the ref and
invalidate it when it finds "key1" already exists in the cache.