### PR TITLE
Fix tests

### DIFF
--- a/ext/gtest/CMakeLists.txt
+++ b/ext/gtest/CMakeLists.txt
@@ -3,7 +3,8 @@ project(gtest_builder C CXX)
 include(ExternalProject)
 
 ExternalProject_Add(googletest
-    SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.7.0
     CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
                -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
                -DCMAKE_CXX_FLAGS=${MSVC_COMPILER_DEFS}
@@ -17,4 +18,4 @@ ExternalProject_Get_Property(googletest source_dir)
 set(GTEST_INCLUDE_DIRS ${source_dir}/include PARENT_SCOPE)
 
 ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBS_DIR ${binary_dir} PARENT_SCOPE) 
+set(GTEST_LIBS_DIR ${binary_dir} PARENT_SCOPE)


### PR DESCRIPTION
Download google tests from git with a fixed tag. Svn is no longer
available.