### PR TITLE
Fix redeclared as different kind of symbol issue

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -6,35 +6,35 @@ const int NUM_OF_TEST2_RECORDS = 100;
 const int TEST2_CACHE_CAPACITY = 50;
 
 TEST(CacheTest, SimplePut) {
-    cache::lru_cache<int, int> cache(1);
-    cache.put(7, 777);
-    EXPECT_TRUE(cache.exists(7));
-    EXPECT_EQ(777, cache.get(7));
-    EXPECT_EQ(1, cache.size());
+    cache::lru_cache<int, int> cache_lru(1);
+    cache_lru.put(7, 777);
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(777, cache_lru.get(7));
+    EXPECT_EQ(1, cache_lru.size());
 }
 
 TEST(CacheTest, MissingValue) {
-    cache::lru_cache<int, int> cache(1);
-    EXPECT_THROW(cache.get(7), std::range_error);
+    cache::lru_cache<int, int> cache_lru(1);
+    EXPECT_THROW(cache_lru.get(7), std::range_error);
 }
 
 TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
-    cache::lru_cache<int, int> cache(TEST2_CACHE_CAPACITY);
+    cache::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
 
     for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
-        cache.put(i, i);
+        cache_lru.put(i, i);
     }
 
     for (int i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
-        EXPECT_FALSE(cache.exists(i));
+        EXPECT_FALSE(cache_lru.exists(i));
     }
 
     for (int i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
-        EXPECT_TRUE(cache.exists(i));
-        EXPECT_EQ(i, cache.get(i));
+        EXPECT_TRUE(cache_lru.exists(i));
+        EXPECT_EQ(i, cache_lru.get(i));
     }
 
-    size_t size = cache.size();
+    size_t size = cache_lru.size();
     EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
 }
 


### PR DESCRIPTION
Similar name of cache instance and cache namespace in tests
caused the error: redeclared as different kind of symbol.