### PR TITLE
Added autotools support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,17 @@ build
 
 cpp-lru-cache-test
 obj-x86_64-linux-gnu/
+Makefile.in
+aclocal.m4
+autom4te.cache
+config.guess
+config.h.in
+config.sub
+configure
+depcomp
+install-sh
+ltmain.sh
+m4
+missing
+test-driver
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,22 @@ language: cpp
 
 compiler:
     - gcc
+
+addons:
+  apt:
+    packages:
+      - libunittest++-dev
   
 script: 
     - mkdir build
     - cd build
     - cmake ..
+    - make check
+    - cd ..
+    - sh autogen.sh
+    - mkdir autotools_build
+    - cd autotools_build
+    - sh ../configure
     - make check
 
 notifications:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,8 @@
 include_HEADERS = include/lrucache.hpp
 
-TESTS               = test
+TESTS               = unit_test
 check_PROGRAMS      = unit_test
 
-unit_test_SOURCES   = src/test.cpp
-unit_test_CXXFLAGS  = -std=c++11 -pthread
-unit_test_LDADD     = -lgtest 
+unit_test_SOURCES   = src/unittest++_test.cpp
+unit_test_CXXFLAGS  = -std=c++0x -pthread
+unit_test_LDADD     = -lUnitTest++

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,8 @@
+include_HEADERS = include/lrucache.hpp
+
+TESTS               = test
+check_PROGRAMS      = unit_test
+
+unit_test_SOURCES   = src/test.cpp
+unit_test_CXXFLAGS  = -std=c++11 -pthread
+unit_test_LDADD     = -lgtest 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+test -e ./.autotools_aux || mkdir .autotools_aux
+
+libtoolize -cq
+aclocal -I m4 --install           # Generate aclocal
+autoconf                          # Generate configure script 
+autoheader                        # Generate config.h
+automake --add-missing --copy     # Generate Makefile.in and other scripts 

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 test -e ./.autotools_aux || mkdir .autotools_aux
 
 libtoolize -cq
-aclocal -I m4 --install           # Generate aclocal
+aclocal -I ./ --install           # Generate aclocal
 autoconf                          # Generate configure script 
 autoheader                        # Generate config.h
 automake --add-missing --copy     # Generate Makefile.in and other scripts 

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,12 @@
+AC_INIT([cpp-lru-cache],[0.1], [https://github.com/lamerman/cpp-lru-cache/issues], [],[https://github.com/lamerman/cpp-lru-cache])
+AM_INIT_AUTOMAKE([foreign subdir-objects])                                                                                                                                    
+AM_SILENT_RULES([yes])                                                                                                                                                        
+LT_INIT([dlopen])                                                                                                                                                             
+                                                                                                                                                                              
+AC_CONFIG_HEADERS([config.h])                                                                                                                                                 
+AC_CONFIG_FILES([Makefile ])                                                                                                                                                  
+                                                                                                                                                                              
+AC_PROG_CXX                                                                                                                                                                   
+AC_LANG([C++])                                                                                                                                                                
+
+AC_OUTPUT

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,4 +1,4 @@
-#include "lrucache.hpp"
+#include "../include/lrucache.hpp"
 #include "gtest/gtest.h"
 
 const int NUM_OF_TEST1_RECORDS = 100;

--- a/src/unittest++_test.cpp
+++ b/src/unittest++_test.cpp
@@ -1,0 +1,46 @@
+#include "../include/lrucache.hpp"
+#include <unittest++/UnitTest++.h>
+
+const int NUM_OF_TEST1_RECORDS = 100;
+const int NUM_OF_TEST2_RECORDS = 100;
+const int TEST2_CACHE_CAPACITY = 50;
+
+SUITE(CacheTest) {
+
+TEST(SimplePut) {
+    cache::lru_cache<int, int> cache_lru(1);
+    cache_lru.put(7, 777);
+    CHECK(cache_lru.exists(7));
+    CHECK_EQUAL(777, cache_lru.get(7));
+    CHECK_EQUAL(1, cache_lru.size());
+}
+
+TEST(MissingValue) {
+    cache::lru_cache<int, int> cache_lru(1);
+    CHECK_THROW(cache_lru.get(7), std::range_error);
+}
+
+TEST(KeepsAllValuesWithinCapacity) {
+    cache::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
+
+    for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
+        cache_lru.put(i, i);
+    }
+
+    for (int i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
+        CHECK(not cache_lru.exists(i));
+    }
+
+    for (int i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
+        CHECK(cache_lru.exists(i));
+        CHECK_EQUAL(i, cache_lru.get(i));
+    }
+
+    size_t size = cache_lru.size();
+    CHECK_EQUAL(TEST2_CACHE_CAPACITY, size);
+}
+}
+
+int main(int argc, char **argv) {
+    return UnitTest::RunAllTests();
+}


### PR DESCRIPTION
I added autotools supports, some of the systems I used does not have cmake and I got no permissions so with autotools user just needs a bash intepreter to install our package from the tar ball. 

I also modified the `travis.yml` file to also test the autotools build.

Note that from autotools is easy to create a package :+1:

__EDIT__: I had to add unittest++ since gtest with Autotools is a nightmare. I created a second unit test. 

