### PR TITLE
Capture the LRU victim from the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Example:
 ```
 /**Creates cache with maximum size of three. When the 
    size in achieved every next element will replace the 
-   least recently used one */
-cache::lru_cache<std::string, std::string> cache(3);
+   least recently used one and returns it*/
+cache::lru_cache<std::string, std::string> cache(2);
+std::pair<std::string, std::string> lru_item;
 
-cache.put("one", "one");
-cache.put("two", "two");
+cache.put("one", "one", lru_item);
+cache.put("two", "two", lru_item);
+cache.put("three", "three", lru_item); //lru_item here contains "one" --> "one"
 
 const std::string& from_cache = cache.get("two")
 

--- a/include/lrucache.hpp
+++ b/include/lrucache.hpp
@@ -25,7 +25,8 @@ public:
 		_max_size(max_size) {
 	}
 	
-	void put(const key_t& key, const value_t& value) {
+	bool put(const key_t& key, const value_t& value, std::pair<key_t, value_t>& lru_item) {
+		bool is_lru_item_removed = false;
 		auto it = _cache_items_map.find(key);
 		_cache_items_list.push_front(key_value_pair_t(key, value));
 		if (it != _cache_items_map.end()) {
@@ -38,8 +39,11 @@ public:
 			auto last = _cache_items_list.end();
 			last--;
 			_cache_items_map.erase(last->first);
+			lru_item = _cache_items_list.back();
+			is_lru_item_removed = true;
 			_cache_items_list.pop_back();
 		}
+		return is_lru_item_removed;
 	}
 	
 	const value_t& get(const key_t& key) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -7,7 +7,8 @@ const int TEST2_CACHE_CAPACITY = 50;
 
 TEST(CacheTest, SimplePut) {
     cache::lru_cache<int, int> cache_lru(1);
-    cache_lru.put(7, 777);
+    std::pair<int, int> lru_item;
+    cache_lru.put(7, 777, lru_item);
     EXPECT_TRUE(cache_lru.exists(7));
     EXPECT_EQ(777, cache_lru.get(7));
     EXPECT_EQ(1, cache_lru.size());
@@ -20,9 +21,9 @@ TEST(CacheTest, MissingValue) {
 
 TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
     cache::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
-
+    std::pair<int, int> lru_item;
     for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
-        cache_lru.put(i, i);
+        cache_lru.put(i, i, lru_item);
     }
 
     for (int i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
@@ -36,6 +37,28 @@ TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
 
     size_t size = cache_lru.size();
     EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
+}
+
+TEST(CacheTest2, CapturesTheLRUItem) {
+    cache::lru_cache<int, int> cache_lru(3);
+    std::pair<int, int> lru_item;
+
+    EXPECT_FALSE(cache_lru.put(1, 111, lru_item));
+    EXPECT_FALSE(cache_lru.put(2, 222, lru_item));
+    EXPECT_FALSE(cache_lru.put(3, 333, lru_item));
+    EXPECT_TRUE(cache_lru.put(4, 444, lru_item));
+
+    EXPECT_EQ(1, lru_item.first);
+    EXPECT_EQ(111, lru_item.second);
+
+    EXPECT_TRUE(cache_lru.exists(2));
+    EXPECT_TRUE(cache_lru.exists(3));
+    EXPECT_TRUE(cache_lru.exists(4));
+
+    EXPECT_EQ(222, cache_lru.get(2));
+    EXPECT_EQ(333, cache_lru.get(3));
+    EXPECT_EQ(444, cache_lru.get(4));
+
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR takes care of handling the LRU cache victim. 
Instead of throwing away the victim, this returns the victim, so that the caller decides what to do with the LRU item.

P.S: I've a use-case to capture the victim from the cache and update the same in disk.

Made necessary changes and added tests. Could you please review.